### PR TITLE
additional sensors for air pressure

### DIFF
--- a/custom_components/meteo-swiss/const.py
+++ b/custom_components/meteo-swiss/const.py
@@ -113,5 +113,19 @@ SENSOR_TYPES = {
         SENSOR_TYPE_ICON: "mdi:gauge",
         SENSOR_TYPE_CLASS: None,
         SENSOR_DATA_ID: "prestas0"
+    },
+    "pressure_qff": {
+        SENSOR_TYPE_NAME: "pressure_qff",
+        SENSOR_TYPE_UNIT: PRESSURE_HPA,
+        SENSOR_TYPE_ICON: "mdi:gauge",
+        SENSOR_TYPE_CLASS: None,
+        SENSOR_DATA_ID: "pp0qffs0"
+    },
+    "pressure_qnh": {
+        SENSOR_TYPE_NAME: "pressure_qnh",
+        SENSOR_TYPE_UNIT: PRESSURE_HPA,
+        SENSOR_TYPE_ICON: "mdi:gauge",
+        SENSOR_TYPE_CLASS: None,
+        SENSOR_DATA_ID: "pp0qnhs0"
     }
 }

--- a/custom_components/meteo-swiss/weather.py
+++ b/custom_components/meteo-swiss/weather.py
@@ -72,9 +72,23 @@ class MeteoSwissWeather(WeatherEntity):
         try:
             return float(self._condition[0]['prestas0'])
         except:
-            _LOGGER.debug("Error converting pressure %s"%self._condition[0]['prestas0'])
+            _LOGGER.debug("Error converting pressure (qfe) %s"%self._condition[0]['prestas0'])
+            return None
+    @property
+    def pressure_qff(self):
+        try:
+            return float(self.condition[0]['pp0qffs0'])
+        except:
+            _LOGGER.debug("Error converting pressure (qff) %s"%self._condition[0]['pp0qffs0'])
             return None
 
+    @property
+    def pressure_qnh(self):
+        try:
+            return float(self.condition[0]['pp0qnhs0'])
+        except:
+            _LOGGER.debug("Error converting pressure (qnh) %s"%self._condition[0]['pp0qnhs0'])
+            return None
     @property
     def state(self):
         symbolId = self._forecastData["data"]["current"]['weather_symbol_id']


### PR DESCRIPTION
Additional sensors for air pressure:
- QFF: Air pressure, reduced to sea level (calculation based on current
measurements)
- QNH: Air pressure, reduced to sea level (calculation based on standard
atmosphere used in aviation ISA = International Standard Atmosphere)