### PR TITLE
Issue 67: Remove deprecated overrides on WeatherEntity

### DIFF
--- a/custom_components/meteo-swiss/config_flow.py
+++ b/custom_components/meteo-swiss/config_flow.py
@@ -3,7 +3,7 @@ import logging
 
 import re
 import voluptuous as vol
-from homeassistant.const import CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.const import CONF_NAME
 from homeassistant import config_entries
 from homeassistant.core import callback
 from .const import DOMAIN,CONF_POSTCODE,CONF_STATION,CONF_ENABLESENSORS

--- a/custom_components/meteo-swiss/sensor.py
+++ b/custom_components/meteo-swiss/sensor.py
@@ -1,33 +1,7 @@
 from hamsclient import meteoSwissClient
 
-import datetime
 import logging
 
-
-import voluptuous as vol
-import re
-import sys
-
-import  homeassistant.core as hass
-
-from homeassistant.components.weather import (
-    ATTR_FORECAST_CONDITION,
-    ATTR_FORECAST_TEMP,
-    ATTR_FORECAST_TEMP_LOW,
-    ATTR_FORECAST_TIME,
-    WeatherEntity,
-)
-from homeassistant.const import (
-    TEMP_CELSIUS,
-    CONF_LATITUDE, 
-    CONF_LONGITUDE,
-)
-import homeassistant.util.dt as dt_util
-
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.util import Throttle
-import homeassistant.helpers.config_validation as cv
-import async_timeout
 from homeassistant.helpers.entity import Entity
 
 from .const import (


### PR DESCRIPTION
Deprecated Overrides:
The methods temperature, pressure and wind_speed will become final and the "native" methods should be used, e.g
native_temperature, etc.
For the units there are corresponding attributes, e.g. _attr_native_temperature_unit 

Also I removed unused imports.

